### PR TITLE
docs(video): add videotrigger video

### DIFF
--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -3,6 +3,7 @@ name: "youtube"
 title: "YouTube"
 description: "Tasks that interact with the YouTube Data API."
 body: "Provide API credentials and channel or video identifiers to search videos, list playlists, or manage uploads, returning metadata for content and reporting workflows."
-videos: []
+videos:
+  - "https://www.youtube.com/watch?v=jICOZjTsTPg"
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"


### PR DESCRIPTION
Adding a new video that covers the YouTube Trigger. It's not a guide specific to the YouTube video, more of a feature showcase.