### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/youtube/AbstractYoutubeTask.java
+++ b/src/main/java/io/kestra/plugin/youtube/AbstractYoutubeTask.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -27,6 +28,7 @@ public abstract class AbstractYoutubeTask extends Task {
         description = "The OAuth2 access token for YouTube API authentication"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> accessToken;
 
     @Schema(
@@ -34,6 +36,7 @@ public abstract class AbstractYoutubeTask extends Task {
         description = "Name of the application making the request"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> applicationName = Property.ofValue("kestra-yt-plugin");
 
     protected YouTube createYoutubeService(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/youtube/CommentTrigger.java
+++ b/src/main/java/io/kestra/plugin/youtube/CommentTrigger.java
@@ -82,6 +82,7 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
         description = "The Oauth2 access token for YouTube API authentication"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> accessToken;
 
     @Schema(
@@ -89,13 +90,14 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
         description = "List of YouTube video IDs to monitor for new comments"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> videoIds;
 
     @Schema(
         title = "Polling interval",
         description = "How often to check for new comments"
     )
-    @PluginProperty
+    @PluginProperty(group = "execution")
     @Builder.Default
     private Duration interval = Duration.ofMinutes(30);
 
@@ -104,6 +106,7 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
         description = "Maximum number of recent comments to check per video – acceptable values are 1 to 100, inclusive."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Integer> maxResults = Property.ofValue(20);
 
     @Schema(
@@ -111,6 +114,7 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
         description = "Order of the comments to retrieve (options:time or relevance)"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> order = Property.ofValue("time");
 
     @Schema(
@@ -118,6 +122,7 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
         description = "The name of the application making the API request"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> applicationName = Property.ofValue("kestra-yt-plugin");
 
     @Override

--- a/src/main/java/io/kestra/plugin/youtube/OAuth2.java
+++ b/src/main/java/io/kestra/plugin/youtube/OAuth2.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -53,6 +54,7 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
         description = "OAuth2 client ID from Google Cloud console project"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> clientId;
 
     @Schema(
@@ -60,6 +62,7 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
         description = "OAuth2 client secret from Google Cloud console project"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> clientSecret;
 
     @Schema(
@@ -67,6 +70,7 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
         description = "Refresh token obtained during the initial authorization flow"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> refreshToken;
 
     @Schema(
@@ -74,6 +78,7 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
         description = "The Google OAuth2 token endpoint URL"
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<String> tokenUrl = Property.ofValue("https://oauth2.googleapis.com/token");
 
     @Override

--- a/src/main/java/io/kestra/plugin/youtube/VideoStats.java
+++ b/src/main/java/io/kestra/plugin/youtube/VideoStats.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,6 +64,7 @@ public class VideoStats extends AbstractYoutubeTask implements RunnableTask<Vide
         description = "List of YouTube video IDs to retrieve statistics for"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> videoIds;
 
     @Schema(
@@ -70,6 +72,7 @@ public class VideoStats extends AbstractYoutubeTask implements RunnableTask<Vide
         description = "Whether to include video snippet data (title, description, thumbnail, etc.) in addition to statistics"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeSnippet = Property.ofValue(false);
 
     @Schema(
@@ -77,6 +80,7 @@ public class VideoStats extends AbstractYoutubeTask implements RunnableTask<Vide
         description = "Maximum number of items that should be returned in the result set – acceptable values are 1 to 50, inclusive."
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<Integer> maxResults = Property.ofValue(5);
 
     @Schema(
@@ -84,6 +88,7 @@ public class VideoStats extends AbstractYoutubeTask implements RunnableTask<Vide
         description = "Whether to include channels content details"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeContentDetails = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/youtube/VideoTrigger.java
+++ b/src/main/java/io/kestra/plugin/youtube/VideoTrigger.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,6 +72,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
         description = "The OAuth2 access token for YouTube API authentication"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> accessToken;
 
     @Schema(
@@ -78,6 +80,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
         description = "The YouTube channel ID to monitor for new videos"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channelId;
 
     @Schema(
@@ -85,6 +88,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
         description = "How often to check for new videos"
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Duration interval = Duration.ofHours(1);
 
     @Schema(
@@ -92,6 +96,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
         description = "Maximum number of recent videos to check (1-50)"
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Integer> maxResults = Property.ofValue(5);
 
     @Schema(
@@ -99,6 +104,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
         description = "Name of the application making the API requests"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> applicationName = Property.ofValue("kestra-yt-plugin");
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712