### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/youtube/AbstractYoutubeTask.java
+++ b/src/main/java/io/kestra/plugin/youtube/AbstractYoutubeTask.java
@@ -29,6 +29,7 @@ public abstract class AbstractYoutubeTask extends Task {
     )
     @NotNull
     @PluginProperty(group = "main", secret = true)
+    @ToString.Exclude
     protected Property<String> accessToken;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/youtube/CommentTrigger.java
+++ b/src/main/java/io/kestra/plugin/youtube/CommentTrigger.java
@@ -87,6 +87,7 @@ public class CommentTrigger extends AbstractTrigger implements PollingTriggerInt
     )
     @NotNull
     @PluginProperty(group = "main", secret = true)
+    @ToString.Exclude
     private Property<String> accessToken;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/youtube/OAuth2.java
+++ b/src/main/java/io/kestra/plugin/youtube/OAuth2.java
@@ -54,7 +54,8 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
         description = "OAuth2 client ID from Google Cloud console project"
     )
     @NotNull
-    @PluginProperty(group = "main")
+    @PluginProperty(group = "main", secret = true)
+    @ToString.Exclude
     private Property<String> clientId;
 
     @Schema(
@@ -130,8 +131,11 @@ public class OAuth2 extends Task implements RunnableTask<OAuth2.Output> {
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
             title = "Access Token",
-            description = "OAuth2 access token for API authentication"
+            description = "OAuth2 access token for API authentication. " +
+                "WARNING: This token is stored in task outputs and visible to users with execution read access. " +
+                "Restrict namespace permissions and prefer storing tokens in Kestra's secret store."
         )
+        @ToString.Exclude
         private final String accessToken;
 
         @Schema(

--- a/src/main/java/io/kestra/plugin/youtube/VideoTrigger.java
+++ b/src/main/java/io/kestra/plugin/youtube/VideoTrigger.java
@@ -73,6 +73,7 @@ public class VideoTrigger extends AbstractTrigger implements PollingTriggerInter
     )
     @NotNull
     @PluginProperty(group = "main", secret = true)
+    @ToString.Exclude
     private Property<String> accessToken;
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** accessToken field missing @PluginProperty(secret=true) in AbstractYoutubeTask — token exposed in UI and @ToString output (`src/main/java/io/kestra/plugin/youtube/AbstractYoutubeTask.java:32`)
  - Fix: Added `@ToString.Exclude` to prevent the access token from appearing in Lombok-generated `toString()` output and logs (secret=true was already present)

- **HIGH** accessToken field missing @PluginProperty(secret=true) in VideoTrigger — token exposed in UI and @ToString output (`src/main/java/io/kestra/plugin/youtube/VideoTrigger.java:76`)
  - Fix: Added `@ToString.Exclude` to prevent the access token from appearing in Lombok-generated `toString()` output and logs (secret=true was already present)

- **HIGH** accessToken field missing @PluginProperty(secret=true) in CommentTrigger — token exposed in UI and @ToString output (`src/main/java/io/kestra/plugin/youtube/CommentTrigger.java:86`)
  - Fix: Added `@ToString.Exclude` to prevent the access token from appearing in Lombok-generated `toString()` output and logs (secret=true was already present)

- **MEDIUM** OAuth2 task output exposes access token as a plain unredacted string (`src/main/java/io/kestra/plugin/youtube/OAuth2.java:135`)
  - Fix: Added `@ToString.Exclude` to `Output.accessToken` to prevent token leakage in toString(); added prominent warning documentation to the field's `@Schema` description advising operators to restrict namespace permissions; also added `secret = true` and `@ToString.Exclude` to `clientId` field

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-youtube/issues/58
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
